### PR TITLE
fix: add catch-all can?/3 clause for custom item actions

### DIFF
--- a/test/ash_backpex/authz_test.exs
+++ b/test/ash_backpex/authz_test.exs
@@ -41,6 +41,20 @@ defmodule AshBackpex.AuthzTest do
     end
   end
 
+  describe "AshBackpex.LiveResource :: can? with custom item actions" do
+    test "returns true for unknown actions that don't exist on the resource" do
+      # :promote is not an Ash action on Item, so fallback returns true
+      assert TestCustomItemActionLive.can?(%{current_user: nil}, :promote, %{})
+      assert TestCustomItemActionLive.can?(%{current_user: nil}, :some_unknown_action, %{})
+    end
+
+    test "checks Ash authorization when action exists on resource" do
+      # :read exists on Item resource, so it checks Ash.can?
+      # Item has no policies, so it should return true
+      assert TestCustomItemActionLive.can?(%{current_user: nil}, :read, %{})
+    end
+  end
+
   describe "AshBackpex.Adapter :: it can" do
     test "list/3" do
       user = user()

--- a/test/support/test_live.ex
+++ b/test/support/test_live.ex
@@ -113,3 +113,46 @@ defmodule TestLayout do
     """
   end
 end
+
+# Custom item action for testing can?/3 fallback
+defmodule TestPromoteItemAction do
+  @moduledoc false
+  use BackpexWeb, :item_action
+
+  @impl Backpex.ItemAction
+  def icon(assigns, _item) do
+    ~H"""
+    <Backpex.HTML.CoreComponents.icon
+      name="hero-arrow-up-circle"
+      class="h-5 w-5 cursor-pointer transition duration-75 hover:scale-110 hover:text-success"
+    />
+    """
+  end
+
+  @impl Backpex.ItemAction
+  def label(_assigns, _item), do: "Promote"
+
+  @impl Backpex.ItemAction
+  def handle(socket, _items, _data) do
+    {:ok, socket}
+  end
+end
+
+# LiveResource with custom item action for testing can?/3 fallback
+defmodule TestCustomItemActionLive do
+  @moduledoc false
+  use AshBackpex.LiveResource
+
+  backpex do
+    resource(AshBackpex.TestDomain.Item)
+    layout({TestLayout, :admin})
+
+    item_actions do
+      action :promote, TestPromoteItemAction
+    end
+
+    fields do
+      field(:name)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes crash when using custom `item_actions` in AshBackpex.LiveResource
- Adds a fallback `can?/3` clause that handles custom actions

## Problem
When using custom `item_actions` in an AshBackpex.LiveResource, the page crashes with:
```
no function clause matching in MyAppWeb.Admin.UserLive."-inlined-can?/3-"/3
```

This happens because the transformer generates specific `can?/3` function clauses for standard actions (`:new`, `:index`, `:show`, `:edit`, `:delete`) but does NOT generate a catch-all fallback clause.

## Solution
Added a catch-all `can?/3` clause after the destroy_action block that:
1. Returns `true` for actions that don't exist on the Ash resource (custom UI actions)
2. Checks Ash authorization using `Ash.can?` for actions that do exist on the resource

This mirrors the base Backpex.LiveResource behavior (which returns `true` by default) while integrating with Ash's authorization system when applicable.

## Test plan
- [x] Added `TestPromoteItemAction` - a custom item action with icon for testing
- [x] Added `TestCustomItemActionLive` - a LiveResource with the custom item action
- [x] Added tests verifying:
  - Unknown actions (like `:promote`) return `true`
  - Known Ash actions (like `:read`) check Ash authorization
- [x] All existing tests pass