### PR TITLE
WIP: feat: add support for ash primary key

### DIFF
--- a/lib/ash_backpex/live_resource/dsl.ex
+++ b/lib/ash_backpex/live_resource/dsl.ex
@@ -342,7 +342,6 @@ defmodule AshBackpex.LiveResource.Dsl do
       ],
       init_order: [
         doc: "Order that will be used when no other order options are given.",
-        default: %{by: :id, direction: :asc},
         type: {
           :or,
           [
@@ -374,6 +373,10 @@ defmodule AshBackpex.LiveResource.Dsl do
         doc: "If the \"Save & Continue editing\" button is shown on form views.",
         type: :boolean,
         default: false
+      ],
+      primary_key: [
+        doc: "The primary key attribute used for identifying items. Defaults to :id.",
+        type: :atom
       ],
       on_mount: [
         doc: """


### PR DESCRIPTION
Instead of defaulting to :id without possibility to change it, this commit adds option for setting primary_key.

But as we are using Ash, we already know what is the primary key of our resource, so by default that one is used.

Please definitely feel free to improve upon this as I'm Elixir beginner and I might got it completely wrong.

I made close to minimal change which supports my use case - having some tables with differently named primary keys. I didn't really test if compound keys exception is working.

I suppose it would be great to add test for this but I'm not 100 % sure how to approach this and I would ofc like to know if you want to merge this. All current tests are passing.