### PR TITLE
Feat/item actions only except

### DIFF
--- a/lib/ash_backpex/live_resource/dsl.ex
+++ b/lib/ash_backpex/live_resource/dsl.ex
@@ -213,7 +213,7 @@ defmodule AshBackpex.LiveResource.Dsl do
     @moduledoc """
     Configuration options for `Backpex.ItemAction`
     """
-    defstruct [:name, :module]
+    defstruct [:name, :module, :only, :except]
   end
 
   @item_action %Spark.Dsl.Entity{
@@ -228,7 +228,17 @@ defmodule AshBackpex.LiveResource.Dsl do
          type: :module,
          required: true,
          doc: "The module to use for the item action. You must create the module"
-       ]}
+       ]},
+      only: [
+        type: {:list, :atom},
+        doc:
+          "The only key is used to include specified placements, meaning the item action will only appear in the specified locations."
+      ],
+      except: [
+        type: {:list, :atom},
+        doc:
+          "The except key is used to exclude specified placements, meaning the item action will appear in all locations except those specified."
+      ]
     ]
   }
 

--- a/lib/ash_backpex/live_resource/transformers/generate_backpex.ex
+++ b/lib/ash_backpex/live_resource/transformers/generate_backpex.ex
@@ -296,13 +296,19 @@ defmodule AshBackpex.LiveResource.Transformers.GenerateBackpex do
                  end)
 
         @item_actions Spark.Dsl.Extension.get_entities(__MODULE__, [:backpex, :item_actions])
-                      |> Enum.reduce([], fn action, acc ->
+                      |> Enum.reverse()
+                      |> Enum.reduce([], fn field, acc ->
                         Keyword.put(
                           acc,
-                          action.name,
+                          field.name,
                           %{
-                            module: action.module
+                            module: field.module,
+                            only: field.only,
+                            except: field.except
                           }
+                          |> Map.to_list()
+                          |> Enum.reject(fn {k, v} -> is_nil(v) end)
+                          |> Map.new()
                         )
                       end)
 

--- a/test/ash_backpex/live_resource/transformer_test.exs
+++ b/test/ash_backpex/live_resource/transformer_test.exs
@@ -134,4 +134,36 @@ defmodule AshBackpex.LiveResource.TransformerTest do
       assert function_exported?(TestPostLive, :can?, 3)
     end
   end
+
+  describe "return correct placement for item_actions" do
+    test "include :only option in item action config" do
+      item_actions = TestCustomItemActionLiveWithOnly.item_actions([])
+
+      assert Keyword.has_key?(item_actions, :promote)
+      promote_config = Keyword.get(item_actions, :promote)
+      assert promote_config.only == [:row]
+    end
+
+    test "include :except option in item action config" do
+      item_actions = TestCustomItemActionLiveWithExcept.item_actions([])
+
+      assert Keyword.has_key?(item_actions, :promote)
+      promote_config = Keyword.get(item_actions, :promote)
+      assert promote_config.except == [:index]
+    end
+
+    test "not include :only when not specified" do
+      item_actions = TestCustomItemActionLive.item_actions([])
+
+      promote_config = Keyword.get(item_actions, :promote)
+      refute Map.has_key?(promote_config, :only)
+    end
+
+    test "not include :except when not specified" do
+      item_actions = TestCustomItemActionLiveWithOnly.item_actions([])
+
+      promote_config = Keyword.get(item_actions, :promote)
+      refute Map.has_key?(promote_config, :except)
+    end
+  end
 end

--- a/test/support/test_live.ex
+++ b/test/support/test_live.ex
@@ -170,3 +170,39 @@ defmodule TestNonDefaultPrimaryKeyNameLive do
     end
   end
 end
+
+defmodule TestCustomItemActionLiveWithOnly do
+  @moduledoc false
+  use AshBackpex.LiveResource
+
+  backpex do
+    resource(AshBackpex.TestDomain.Item)
+    layout({TestLayout, :admin})
+
+    item_actions do
+      action :promote, TestPromoteItemAction, only: [:row]
+    end
+
+    fields do
+      field(:name)
+    end
+  end
+end
+
+defmodule TestCustomItemActionLiveWithExcept do
+  @moduledoc false
+  use AshBackpex.LiveResource
+
+  backpex do
+    resource(AshBackpex.TestDomain.Item)
+    layout({TestLayout, :admin})
+
+    item_actions do
+      action :promote, TestPromoteItemAction, except: [:index]
+    end
+
+    fields do
+      field(:name)
+    end
+  end
+end


### PR DESCRIPTION
Added missing support of :only and :except on item actions. Example:

    item_actions do
      action :versions,
             SomeWeb.Admin.Resource,
             only: [:row]
    end