### PR TITLE
feat: allow custom field mappings

### DIFF
--- a/lib/ash_backpex/live_resource/dsl.ex
+++ b/lib/ash_backpex/live_resource/dsl.ex
@@ -309,6 +309,12 @@ defmodule AshBackpex.LiveResource.Dsl do
         doc:
           "Panels to be displayed in the admin create/edit forms. Format: [panel_key: \"Panel Title\"]"
       ],
+      field_mappings: [
+        type: {:map, :atom, :atom},
+        default: %{},
+        doc:
+          "Override default Ash type to Backpex field module mappings. Format: %{Ash.Type.DateTime => MyApp.Fields.CustomDateTime}"
+      ],
       pubsub: [
         doc: "PubSub configuration.",
         type: :keyword_list,

--- a/lib/ash_backpex/live_resource/transformers/generate_backpex.ex
+++ b/lib/ash_backpex/live_resource/transformers/generate_backpex.ex
@@ -146,82 +146,90 @@ defmodule AshBackpex.LiveResource.Transformers.GenerateBackpex do
 
         try_derive_module = fn attribute_name ->
           type = derive_type.(attribute_name)
+          field_mappings = Spark.Dsl.Extension.get_opt(__MODULE__, [:backpex], :field_mappings) || %{}
 
-          case type do
-            Ash.Type.Boolean ->
-              Backpex.Fields.Boolean
+          # Check custom mappings first, then fall back to defaults
+          case Map.get(field_mappings, type) do
+            nil ->
+              case type do
+                Ash.Type.Boolean ->
+                  Backpex.Fields.Boolean
 
-            Ash.Type.String ->
-              attribute_name |> select_or.(Backpex.Fields.Text)
+                Ash.Type.String ->
+                  attribute_name |> select_or.(Backpex.Fields.Text)
 
-            Ash.Type.Atom ->
-              attribute_name |> select_or.(Backpex.Fields.Text)
+                Ash.Type.Atom ->
+                  attribute_name |> select_or.(Backpex.Fields.Text)
 
-            Ash.Type.CiString ->
-              attribute_name |> select_or.(Backpex.Fields.Text)
+                Ash.Type.CiString ->
+                  attribute_name |> select_or.(Backpex.Fields.Text)
 
-            Ash.Type.Time ->
-              Backpex.Fields.Time
+                Ash.Type.Time ->
+                  Backpex.Fields.Time
 
-            Ash.Type.Date ->
-              Backpex.Fields.Date
+                Ash.Type.Date ->
+                  Backpex.Fields.Date
 
-            Ash.Type.UtcDatetime ->
-              Backpex.Fields.DateTime
+                Ash.Type.UtcDatetime ->
+                  Backpex.Fields.DateTime
 
-            Ash.Type.UtcDatetimeUsec ->
-              Backpex.Fields.DateTime
+                Ash.Type.UtcDatetimeUsec ->
+                  Backpex.Fields.DateTime
 
-            Ash.Type.DateTime ->
-              Backpex.Fields.DateTime
+                Ash.Type.DateTime ->
+                  Backpex.Fields.DateTime
 
-            Ash.Type.NaiveDateTime ->
-              Backpex.Fields.DateTime
+                Ash.Type.NaiveDateTime ->
+                  Backpex.Fields.DateTime
 
-            Ash.Type.Integer ->
-              attribute_name |> select_or.(Backpex.Fields.Number)
+                Ash.Type.Integer ->
+                  attribute_name |> select_or.(Backpex.Fields.Number)
 
-            Ash.Type.Float ->
-              attribute_name |> select_or.(Backpex.Fields.Number)
+                Ash.Type.Float ->
+                  attribute_name |> select_or.(Backpex.Fields.Number)
 
-            :belongs_to ->
-              Backpex.Fields.BelongsTo
+                :belongs_to ->
+                  Backpex.Fields.BelongsTo
 
-            :has_many ->
-              Backpex.Fields.HasMany
+                :has_many ->
+                  Backpex.Fields.HasMany
 
-            :count ->
-              Backpex.Fields.Number
+                :count ->
+                  Backpex.Fields.Number
 
-            :exists ->
-              Backpex.Fields.Boolean
+                :exists ->
+                  Backpex.Fields.Boolean
 
-            :sum ->
-              Backpex.Fields.Number
+                :sum ->
+                  Backpex.Fields.Number
 
-            :max ->
-              Backpex.Fields.Number
+                :max ->
+                  Backpex.Fields.Number
 
-            :min ->
-              Backpex.Fields.Number
+                :min ->
+                  Backpex.Fields.Number
 
-            :avg ->
-              Backpex.Fields.Number
+                :avg ->
+                  Backpex.Fields.Number
 
-            {:array, Ash.Type.Atom} ->
-              attribute_name |> multiselect_or.(Backpex.Fields.Text)
+                {:array, Ash.Type.Atom} ->
+                  attribute_name |> multiselect_or.(Backpex.Fields.Text)
 
-            {:array, Ash.Type.String} ->
-              attribute_name |> multiselect_or.(Backpex.Fields.Text)
+                {:array, Ash.Type.String} ->
+                  attribute_name |> multiselect_or.(Backpex.Fields.Text)
 
-            {:array, Ash.Type.CiString} ->
-              attribute_name |> multiselect_or.(Backpex.Fields.Text)
+                {:array, Ash.Type.CiString} ->
+                  attribute_name |> multiselect_or.(Backpex.Fields.Text)
 
-            {:array, Ash.Type.Integer} ->
-              attribute_name |> multiselect_or.(Backpex.Fields.Number)
+                {:array, Ash.Type.Integer} ->
+                  attribute_name |> multiselect_or.(Backpex.Fields.Number)
 
-            {:array, Ash.Type.Float} ->
-              attribute_name |> multiselect_or.(Backpex.Fields.Number)
+                {:array, Ash.Type.Float} ->
+                  attribute_name |> multiselect_or.(Backpex.Fields.Number)
+              end
+
+            custom_module ->
+              custom_module
           end
         end
 

--- a/test/ash_backpex/live_resource/transformer_test.exs
+++ b/test/ash_backpex/live_resource/transformer_test.exs
@@ -103,6 +103,16 @@ defmodule AshBackpex.LiveResource.TransformerTest do
       assert Keyword.get(fields, :author).module == Backpex.Fields.BelongsTo
     end
 
+    test "derive custom Backpex field types with field overrides" do
+      fields = TestCustomFieldMappingsLive.fields()
+
+      # this one is standard and not overridden
+      assert Keyword.get(fields, :title).module == Backpex.Fields.Text
+
+      # this one would be Ash.Type.DateTime if not overridden
+      assert Keyword.get(fields, :published_at).module == Demo.Backpex.Fields.CustomDateTime
+    end
+
     test "derive default and non-default primary key with init_order" do
       assert TestPostLive.config(:primary_key) == :id
 

--- a/test/support/test_live.ex
+++ b/test/support/test_live.ex
@@ -170,3 +170,37 @@ defmodule TestNonDefaultPrimaryKeyNameLive do
     end
   end
 end
+
+defmodule Demo.Backpex.Fields.CustomDateTime do
+  @moduledoc "Dummy field module for testing :field_mappings config override"
+  use Backpex.Field
+
+  @impl Backpex.Field
+  def render_value(assigns) do
+    ~H"<span>{@value}</span>"
+  end
+
+  @impl Backpex.Field
+  def render_form(assigns) do
+    ~H"""
+    <input type="datetime-local" />
+    """
+  end
+end
+
+defmodule TestCustomFieldMappingsLive do
+  @moduledoc false
+  use AshBackpex.LiveResource
+
+  backpex do
+    resource(AshBackpex.TestDomain.Post)
+    layout({TestLayout, :admin})
+
+    field_mappings(%{Ash.Type.DateTime => Demo.Backpex.Fields.CustomDateTime})
+
+    fields do
+      field(:title)
+      field(:published_at)
+    end
+  end
+end


### PR DESCRIPTION
I would like to have some custom fields consistently through whole application and I didn't find any way how to currently do this.

My reasoning is that writing AshBackpex resources should be as brief as possible and I really hate the idea of adding `module` to i.e. each field with date.

Ideal solution would be to have :field_mappings in Application config which would be found by AshBackpex. But I suppose libraries shouldn't be based on anything in application so I'm introducing new "attribute" for resource named field_mappings working like this:

    field_mappings(%{
      Ash.Type.UtcDatetime => MyappWeb.Backpex.Fields.RelativeDateTime,
      Ash.Type.UtcDatetimeUsec => MyappWeb.Backpex.Fields.RelativeDateTime,
      Ash.Type.DateTime => MyappWeb.Backpex.Fields.RelativeDateTime,
      Ash.Type.NaiveDateTime => MyappWeb.Backpex.Fields.RelativeDateTime
    })

That way I can use my custom module with backpex macro which set this as default for all my admin pages.

Simple test covering the functionality is included.

Let me know if you have any objections or if I should improve something.